### PR TITLE
Fix darken_image doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For `tap_action` options, see https://www.home-assistant.io/dashboards/actions/.
   shadow: true # Draws a drop shadow on icons (optional)
   hide_unavailable: false # Hide unavailable entities (optional)
   state_color: true # enable or disable HA colors for all entities
+  darken_image: true # reduce brightness of the background image to constrast with entities
   tap_action:
     action: navigate
     navigation_path: /lovelace/living-room
@@ -35,7 +36,6 @@ For `tap_action` options, see https://www.home-assistant.io/dashboards/actions/.
     - entity: media_player.living_room_tv
       state_color: false # enable or disable HA colors for this entity
       shadow: true # enable a drop shadow on entity icons to contrast with the background
-      darken_image: true # reduce brightness of the background image to constrast with entities
     - entity: switch.fireplace_on_off
     - entity: cover.window_covering
       tap_action:


### PR DESCRIPTION
The `darken_image` setting is not effective on entity level, but on top level.

![Screenshot 2023-08-28 at 10 11 50](https://github.com/junalmeida/homeassistant-minimalistic-area-card/assets/5239330/c76eda50-5d74-4109-8b47-8438398856dd)

![Screenshot 2023-08-28 at 10 12 06](https://github.com/junalmeida/homeassistant-minimalistic-area-card/assets/5239330/c33efbed-3ed6-4a60-a7d8-dfd5e442fb21)
