### PR TITLE
Allow overriding icons based on state values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ For `tap_action` options, see https://www.home-assistant.io/dashboards/actions/.
     - entity: light.living_room_lamp
     - entity: sensor.hallway_humidity
     - entity: sensor.hallway_temperature
+    - entity: binary_sensor.main_door_opening
+      icon: mdi:door
+      state_color: false
+      state:
+        - value: 'on'
+          icon: mdi:door-open
+        - value: 'off'
+          icon: mdi:door-closed
 ```
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/junalmeida/homeassistant-minimalistic-area-card.svg?style=for-the-badge

--- a/src/find-entities.ts
+++ b/src/find-entities.ts
@@ -3,7 +3,9 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { HomeAssistantArea } from "./types";
 
 const arrayFilter = (
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     array: any[],
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     conditions: Array<(value: any) => boolean>,
     maxSize: number
 ) => {
@@ -11,6 +13,7 @@ const arrayFilter = (
         maxSize = array.length;
     }
 
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     const filteredArray: any[] = [];
 
     for (let i = 0; i < array.length && filteredArray.length < maxSize; i++) {

--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -115,6 +115,7 @@ class MinimalisticAreaCard extends LitElement {
         entities.forEach((item) => {
 
             const entity = this.parseEntity(item);
+            // eslint-disable-next-line  @typescript-eslint/no-unused-vars
             const [domain, _] = entity.entity.split('.');
             if (SENSORS.indexOf(domain) !== -1 || entity.attribute) {
                 this._entitiesSensor.push(entity);
@@ -289,6 +290,7 @@ class MinimalisticAreaCard extends LitElement {
     }
 
     computeStateValue(stateObj: HassEntity, entity?: EntityRegistryDisplayEntry) {
+        // eslint-disable-next-line  @typescript-eslint/no-unused-vars
         const [domain, _] = stateObj.entity_id.split(".");
         if (this.isNumericState(stateObj)) {
             const value = Number(stateObj.state);


### PR DESCRIPTION
I have a door sensor that always uses the `mdi:square` as an icon, and I would like to show the icon based on the state.

Example entity config:
```
- entity: binary_sensor.main_door_opening
  icon: mdi:door
  state_color: false
  state:
    - value: 'on'
      icon: mdi:door-open
    - value: 'off'
      icon: mdi:door-closed
```
The change has been verified and works. It is inspired by `custom:button-card`, backward compatible, and can be extended in the future.