### PR TITLE
Override state badge color

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A minimalistic area card to have a control panel of your house on your dashboard
 
 ![Sample preview](docs/sample.png)
 
-Please consider sponsoring if you feel that this project is somehow useful to you.  
+Please consider sponsoring if you feel that this project is somehow useful to you.
 [![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
 
 ## Options
@@ -44,14 +44,25 @@ For `tap_action` options, see https://www.home-assistant.io/dashboards/actions/.
     - entity: light.living_room_lamp
     - entity: sensor.hallway_humidity
     - entity: sensor.hallway_temperature
+      color: blue
     - entity: binary_sensor.main_door_opening
       icon: mdi:door
-      state_color: false
+      state_color: true
       state:
         - value: 'on'
+          color: green
           icon: mdi:door-open
         - value: 'off'
+          color: red
           icon: mdi:door-closed
+```
+
+State based settings:
+```yaml
+states: # array of values
+  - value: value #state value to match
+    icon: mdi:my-icon" #icon used when state match
+    color: color # color used when state match
 ```
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/junalmeida/homeassistant-minimalistic-area-card.svg?style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ For `tap_action` options, see https://www.home-assistant.io/dashboards/actions/.
     - entity: light.living_room_lamp
     - entity: sensor.hallway_humidity
     - entity: sensor.hallway_temperature
+    - entity: binary_sensor.main_door_opening
+      icon: mdi:door
+      state_color: false
+      state:
+        - value: 'on'
+          icon: mdi:door-open
+        - value: 'off'
+          icon: mdi:door-closed
 ```
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/junalmeida/homeassistant-minimalistic-area-card.svg?style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For `tap_action` options, see https://www.home-assistant.io/dashboards/actions/.
 
 State based settings:
 ```yaml
-states: # array of values
+state: # array of values
   - value: value #state value to match
     icon: mdi:my-icon" #icon used when state match
     color: color # color used when state match

--- a/src/find-entities.ts
+++ b/src/find-entities.ts
@@ -3,7 +3,9 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { HomeAssistantArea } from "./types";
 
 const arrayFilter = (
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     array: any[],
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     conditions: Array<(value: any) => boolean>,
     maxSize: number
 ) => {
@@ -11,6 +13,7 @@ const arrayFilter = (
         maxSize = array.length;
     }
 
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
     const filteredArray: any[] = [];
 
     for (let i = 0; i < array.length && filteredArray.length < maxSize; i++) {

--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -46,12 +46,14 @@ type ExtendedEntityConfig = EntitiesCardEntityConfig & {
     suffix?: string;
     show_state?: boolean;
     attribute?: string;
+    color?: string;
     state?: EntityStateConfig[];
 };
 
 type EntityStateConfig = {
     value: string;
     icon?: string;
+    color?: string;
 }
 
 const createEntityNotFoundWarning = (
@@ -272,11 +274,18 @@ class MinimalisticAreaCard extends LitElement {
         const title = `${stateObj.attributes?.friendly_name || stateObj.entity_id}: ${computeStateDisplay(this.hass?.localize, stateObj, this.hass?.locale)}`;
 
         let icon = entityConf.icon
+        let color = entityConf.color
+
         if (entityConf.state !== undefined && entityConf.state.length > 0) {
             const currentState = this.computeStateValue(stateObj, entity)
             const stateConfig = entityConf.state.filter((i) => i.value == currentState)[0]
-            if (stateConfig && stateConfig.icon !== undefined) {
-                icon = stateConfig.icon
+            if (stateConfig) {
+                if (stateConfig.icon !== undefined) {
+                    icon = stateConfig.icon
+                }
+                if (stateConfig.color !== undefined) {
+                    color = stateConfig.color
+                }
             }
         }
 
@@ -289,7 +298,7 @@ class MinimalisticAreaCard extends LitElement {
             .config=${entityConf} class=${classMap({ "state-on": active, })}>
             <state-badge .hass=${this.hass} .stateObj=${stateObj} .title=${title} .overrideIcon=${icon}
                 .stateColor=${entityConf.state_color !== undefined ? entityConf.state_color : this.config.state_color
-                !== undefined ? this.config.state_color : true} class=${classMap({
+                !== undefined ? this.config.state_color : true} .color=${color} class=${classMap({
                     "shadow": this.config.shadow === undefined
                         ? false : this.config.shadow,
                 })}></state-badge>

--- a/src/minimalistic-area-card.ts
+++ b/src/minimalistic-area-card.ts
@@ -115,6 +115,7 @@ class MinimalisticAreaCard extends LitElement {
         entities.forEach((item) => {
 
             const entity = this.parseEntity(item);
+            // eslint-disable-next-line  @typescript-eslint/no-unused-vars
             const [domain, _] = entity.entity.split('.');
             if (SENSORS.indexOf(domain) !== -1 || entity.attribute) {
                 this._entitiesSensor.push(entity);
@@ -289,6 +290,7 @@ class MinimalisticAreaCard extends LitElement {
     }
 
     computeStateValue(stateObj: HassEntity, entity?: EntityRegistryDisplayEntry) {
+        // eslint-disable-next-line  @typescript-eslint/no-unused-vars
         const [domain, _] = stateObj.entity_id.split(".");
         if (this.isNumericState(stateObj)) {
             const value = Number(stateObj.state);


### PR DESCRIPTION
Based on https://github.com/junalmeida/homeassistant-minimalistic-area-card/pull/104

I'll rebase it when the first one gets merged.

Original commit message:

Allow to override color.

Examples:
Based on state values:
```
- entity: binary_sensor.main_door_opening
  icon: mdi:door
  state:
      - value: 'on'
        color: green
        icon: mdi:door-open
      - value: 'off'
        color: red
        icon: mdi:door
```

On entity:
```
- entity: light.stairs_leds
  icon: mdi:stairs
  color: blue
  tap_action:
      action: more-info
```

State value settings has higher priority
